### PR TITLE
Add functionality to retrieve and filter JIRA ticket comments

### DIFF
--- a/jirafa-guide.md
+++ b/jirafa-guide.md
@@ -119,6 +119,23 @@ Runs an arbitrary JQL query and returns matching tickets in a specified format.
   - `items_per_batch`: Number of tickets to fetch per batch.
   - `output_format`: Output format (table, CSV, JSON).
 
+### 11. `comments`
+
+Retrieves comments from a JIRA ticket with optional filtering.
+
+#### Usage:
+
+```bash
+jirafa.py comments <issue_key> --filter <filters> --max_results <max_results> --output <output>
+```
+
+- **Filters**:
+
+  - author:<name>: Filter comments by author name
+  - text:<string>: Filter comments containing specific text
+  - date:<yyyy-mm-dd>: Filter comments from a specific date
+  - date:<start_date> to <end_date>: Filter comments within a date range
+
 ## CLI Commands
 
 The tool uses the `Click` library to define CLI commands.


### PR DESCRIPTION
## Description
This PR adds a new command to Jirafa that allows users to retrieve and filter comments from JIRA tickets. This functionality was requested to improve the tool's capabilities for ticket analysis and reporting.

## New Features
- New `comments` command that retrieves comments from a JIRA ticket
- Filtering capabilities:
  - By author name
  - By text content
  - By specific date
  - By date range
- Output formats: table (default), CSV, and JSON
- Option to limit the number of comments returned

## Example Usage
```bash
# Get all comments from a ticket
python jirafa.py comments ISSUE-123

# Filter comments by author
python jirafa.py comments ISSUE-123 --filter "author:JohnDoe"

# Filter comments containing specific text
python jirafa.py comments ISSUE-123 --filter "text:important"

# Filter comments from a specific date
python jirafa.py comments ISSUE-123 --filter "date:2023-01-15"

# Filter comments in a date range
python jirafa.py comments ISSUE-123 --filter "date:2023-01-01 to 2023-01-31"

# Combine multiple filters
python jirafa.py comments ISSUE-123 --filter "author:JohnDoe" --filter "text:important"

# Limit the number of results
python jirafa.py comments ISSUE-123 --max_results 5

# Output as JSON
python jirafa.py comments ISSUE-123 --output json
```

## Documentation
- Updated `jirafa-guide.md` with the new command details
- Added usage examples to `readme.md`
